### PR TITLE
fix NameError when opening uncompressed file

### DIFF
--- a/src/dynamo/programs/dynamo2xyz
+++ b/src/dynamo/programs/dynamo2xyz
@@ -15,7 +15,7 @@ def loadXMLFile(filename):
         f.close()
         return doc
     else:
-        return etree.parse(filename)
+        return ET.parse(filename)
 
 import sys
 if len(sys.argv) == 1:


### PR DESCRIPTION
This simple change fixes a NameError in dynamo2xyz which occurs when opening an uncompressed file.
